### PR TITLE
New API proposal: toElmDecoderWithSources, toElmTypeWithSources

### DIFF
--- a/test/CommentDecoderWithOptionsPost.elm
+++ b/test/CommentDecoderWithOptionsPost.elm
@@ -1,0 +1,12 @@
+module Main (..) where
+
+
+decodeComment : Json.Decode.Decoder Comment
+decodeComment =
+  Json.Decode.succeed Comment
+    |: ("postPostId" := Json.Decode.int)
+    |: ("postText" := Json.Decode.string)
+    |: ("postMainCategories" := Json.Decode.tuple2 (,) Json.Decode.string Json.Decode.string)
+    |: ("postPublished" := Json.Decode.bool)
+    |: ("postCreated" := Json.Decode.Extra.date)
+    |: ("postTags" := Json.Decode.map Dict.fromList (Json.Decode.list (Json.Decode.tuple2 (,) Json.Decode.string Json.Decode.int)))

--- a/test/CommentEncoderWithOptionsPost.elm
+++ b/test/CommentEncoderWithOptionsPost.elm
@@ -1,0 +1,13 @@
+module Main (..) where
+
+
+encodeComment : Comment -> Json.Encode.Value
+encodeComment x =
+  Json.Encode.object
+    [ ( "postPostId", Json.Encode.int x.postId )
+    , ( "postText", Json.Encode.string x.text )
+    , ( "postMainCategories", Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string x.mainCategories )
+    , ( "postPublished", Json.Encode.bool x.published )
+    , ( "postCreated", (Json.Encode.string << Exts.Date.toISOString) x.created )
+    , ( "postTags", Exts.Json.Encode.dict Json.Encode.string Json.Encode.int x.tags )
+    ]

--- a/test/CommentTypeWithOptionsPost.elm
+++ b/test/CommentTypeWithOptionsPost.elm
@@ -1,0 +1,11 @@
+module Main (..) where
+
+
+type alias Comment =
+  { postPostId : Int
+  , postText : String
+  , postMainCategories : ( String, String )
+  , postPublished : Bool
+  , postCreated : Date
+  , postTags : Dict String Int
+  }


### PR DESCRIPTION
When using elm-export to generate Elm functions (plug: https://github.com/mattjbray/servant-elm), I've found it useful to have functions that return `(String, [String])`:

```haskell
(String    -- A type name (or decoder expression) for use 
           -- in a function signature (or function body)
,[String]) -- A list of type (or decoder) definitions required
           -- to use the type name (or decoder expression).
```

For example:

```haskell
toElmTypeWithSources (Proxy :: Proxy [Post])
-- => ("List Post", ["data Post = ..."
--                  ,"data Comment = ..."
--                  ])

toElmDecoderWithSources (Proxy :: Proxy [Post])
-- => ("list decodePost", ["decodePost = ..."
--                        ,"decodeComment = ..."
--                        ])
```

This also allows generating type signatures / decoder expressions for non-user-defined types:

```haskell
toElmTypeWithSources (Proxy :: Proxy (Maybe [String]))
-- => ("maybe (list string)", [])
```

I've thrown together an implementation here, but I'd be interested to hear whether you think this is a good idea or not.