### PR TITLE
Fixes for the Unit type.

### DIFF
--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -7,6 +7,7 @@ module Elm.Decoder (toElmDecoderSource, toElmDecoderSourceWith)
        where
 
 import           Control.Monad.Reader
+import           Data.List            (intercalate)
 import           Elm.Common
 import           Elm.Type
 import           Text.Printf
@@ -55,6 +56,15 @@ render (Primitive "Float") = return "Json.Decode.float"
 render (Primitive "Date") = return "Json.Decode.Extra.date"
 
 render (Primitive "Bool") = return "Json.Decode.bool"
+
+render (Primitive "()") =
+  return $ intercalate "\n"
+    ["Json.Decode.customDecoder (Json.Decode.list Json.Decode.value)"
+    ,"          (\\jsonList ->"
+    ,"             case jsonList of"
+    ,"               [] -> Result.Ok ()"
+    ,"               _  -> Result.Err \"expecting a zero-length array\")"
+    ]
 
 render (Field t) = render t
 

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -52,6 +52,7 @@ render  (Primitive "Double") = return "Json.Encode.float"
 render  (Primitive "Float") = return "Json.Encode.float"
 render  (Primitive "Date") = return "(Json.Encode.string << Exts.Date.toISOString)"
 render  (Primitive "Bool") = return "Json.Encode.bool"
+render  (Primitive "()") = return "(\\_ -> Json.Encode.list [])"
 render  (Field t) = render t
 
 toElmEncoderSourceWith :: ElmType a => Options -> a -> String

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -13,6 +13,9 @@ render (TopLevel (DataType dataTypeName record@(Record _ _))) =
 render (TopLevel (DataType d s@(Sum _ _))) =
   printf "type %s\n  = %s" d <$> render s
 
+render (TopLevel (DataType d c@(Constructor _ _))) =
+  printf "type %s\n  = %s" d <$> render c
+
 render (DataType d _) = return d
 render (Primitive s) = return s
 

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -35,6 +35,9 @@ class ElmType a  where
   default toElmType :: (Generic a,GenericElmType (Rep a)) => a -> ElmTypeExpr
   toElmType = genericToElmType . from
 
+instance ElmType () where
+    toElmType _ = Primitive "()"
+
 instance ElmType Bool where
     toElmType _ = Primitive "Bool"
 

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -40,6 +40,9 @@ data Position
   | End
   deriving (Generic,ElmType)
 
+data NoContent = NoContent
+  deriving (Generic,ElmType)
+
 spec :: Hspec.Spec
 spec =
   do toElmTypeSpec
@@ -61,6 +64,10 @@ toElmTypeSpec =
        shouldMatchTypeSource defaultOptions
                              (Proxy :: Proxy Position)
                              "test/PositionType.elm"
+     it "toElmTypeSource NoContent" $
+       shouldMatchTypeSource defaultOptions
+                             (Proxy :: Proxy NoContent)
+                             "test/NoContentType.elm"
      it "toElmTypeSourceWithOptions Post" $
        shouldMatchTypeSource
          (defaultOptions {fieldLabelModifier = withPrefix "post"})

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -21,7 +21,8 @@ data Post =
        ,age      :: Maybe Double
        ,comments :: [Comment]
        ,promoted :: Maybe Comment
-       ,author   :: Maybe String}
+       ,author   :: Maybe String
+       ,nothing  :: ()}
   deriving (Generic,ElmType)
 
 data Comment =

--- a/test/NoContentType.elm
+++ b/test/NoContentType.elm
@@ -1,0 +1,5 @@
+module Main (..) where
+
+
+type NoContent
+  = NoContent

--- a/test/PostDecoder.elm
+++ b/test/PostDecoder.elm
@@ -10,3 +10,8 @@ decodePost =
     |: ("comments" := Json.Decode.list decodeComment)
     |: ("promoted" := Json.Decode.maybe decodeComment)
     |: ("author" := Json.Decode.maybe Json.Decode.string)
+    |: ("nothing" := Json.Decode.customDecoder (Json.Decode.list Json.Decode.value)
+          (\jsonList ->
+             case jsonList of
+               [] -> Result.Ok ()
+               _  -> Result.Err "expecting a zero-length array"))

--- a/test/PostDecoderWithOptions.elm
+++ b/test/PostDecoderWithOptions.elm
@@ -10,3 +10,8 @@ decodePost =
     |: ("postComments" := Json.Decode.list decodeComment)
     |: ("postPromoted" := Json.Decode.maybe decodeComment)
     |: ("postAuthor" := Json.Decode.maybe Json.Decode.string)
+    |: ("postNothing" := Json.Decode.customDecoder (Json.Decode.list Json.Decode.value)
+          (\jsonList ->
+             case jsonList of
+               [] -> Result.Ok ()
+               _  -> Result.Err "expecting a zero-length array"))

--- a/test/PostEncoder.elm
+++ b/test/PostEncoder.elm
@@ -10,4 +10,5 @@ encodePost x =
     , ( "comments", (Json.Encode.list << List.map encodeComment) x.comments )
     , ( "promoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.promoted )
     , ( "author", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.author )
+    , ( "nothing", (\_ -> Json.Encode.list []) x.nothing )
     ]

--- a/test/PostEncoderWithOptions.elm
+++ b/test/PostEncoderWithOptions.elm
@@ -10,4 +10,5 @@ encodePost x =
     , ( "postComments", (Json.Encode.list << List.map encodeComment) x.comments )
     , ( "postPromoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.promoted )
     , ( "postAuthor", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.author )
+    , ( "postNothing", (\_ -> Json.Encode.list []) x.nothing )
     ]

--- a/test/PostType.elm
+++ b/test/PostType.elm
@@ -8,4 +8,5 @@ type alias Post =
   , comments : List Comment
   , promoted : Maybe Comment
   , author : Maybe String
+  , nothing : ()
   }

--- a/test/PostTypeWithOptions.elm
+++ b/test/PostTypeWithOptions.elm
@@ -8,4 +8,5 @@ type alias Post =
   , postComments : List Comment
   , postPromoted : Maybe Comment
   , postAuthor : Maybe String
+  , postNothing : ()
   }


### PR DESCRIPTION
I currently have this special case, which is annoying me:
https://github.com/mattjbray/servant-elm/blob/463f4fca67715d3a85233c96ff2b660d4770a374/src/Servant/Elm/Client.hs#L155-L159

(It's for Servant endpoints with a `()` response, e.g. a `POST` request that returns nothing.)

This change means I could do away with it.

However the encoder doesn't make a lot of sense -- how do you encode `()` into JSON?
