### PR TITLE
Add an ElmType instance for ElmTypeExpr.

### DIFF
--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -35,6 +35,9 @@ class ElmType a  where
   default toElmType :: (Generic a,GenericElmType (Rep a)) => a -> ElmTypeExpr
   toElmType = genericToElmType . from
 
+instance ElmType ElmTypeExpr where
+    toElmType = id
+
 instance ElmType Bool where
     toElmType _ = Primitive "Bool"
 


### PR DESCRIPTION
This allows me to keep an `ElmTypeExpr` value around and generate types/decoders/encoders as needed.