### PR TITLE
Allow selecting Elm syntax version.

### DIFF
--- a/src/Elm.hs
+++ b/src/Elm.hs
@@ -1,6 +1,6 @@
 module Elm (module X) where
 
-import           Elm.Common  as X (Options (..), defaultOptions)
+import           Elm.Common  as X (ElmVersion(..), Options (..), defaultOptions)
 import           Elm.Decoder as X
 import           Elm.Encoder as X
 import           Elm.File    as X

--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -14,8 +14,15 @@ parenthesize :: ElmTypeExpr -> String -> String
 parenthesize t s =
   if isTopLevel t then s else "(" ++ s ++ ")"
 
+data ElmVersion
+  = V_0_16
+  | V_0_17
+  deriving (Show, Eq, Ord)
+
 data Options =
-  Options {fieldLabelModifier :: String -> String}
+  Options {elmVersion :: ElmVersion
+          ,fieldLabelModifier :: String -> String}
 
 defaultOptions :: Options
-defaultOptions = Options {fieldLabelModifier = id}
+defaultOptions = Options {elmVersion = V_0_16
+                         ,fieldLabelModifier = id}


### PR DESCRIPTION
I think this is the only change required to generate code for `elm-0.17`.