### PR TITLE
Support Elm 0.17 syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /.stack-work/
 /TAGS
+elm-stuff
+.idea
+index.html
+

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "test"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.5 <= v < 5.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}

--- a/src/Elm/File.hs
+++ b/src/Elm/File.hs
@@ -29,7 +29,7 @@ specToFile rootDir spec =
       body =
         intercalate
           "\n\n"
-          (printf "module %s where" namespaceString : declarations spec)
+          (printf "module %s exposing (..)" namespaceString : declarations spec)
   in do printf "Writing: %s\n" file
         writeFile file body
 

--- a/test/CommentDecoder.elm
+++ b/test/CommentDecoder.elm
@@ -1,6 +1,12 @@
 module Main exposing (..)
 
 
+import Dict
+import Json.Decode exposing ((:=))
+import Json.Decode.Extra exposing ((|:))
+import CommentType exposing (..)
+
+
 decodeComment : Json.Decode.Decoder Comment
 decodeComment =
   Json.Decode.succeed Comment

--- a/test/CommentDecoder.elm
+++ b/test/CommentDecoder.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 decodeComment : Json.Decode.Decoder Comment

--- a/test/CommentDecoderWithOptions.elm
+++ b/test/CommentDecoderWithOptions.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 decodeComment : Json.Decode.Decoder Comment

--- a/test/CommentEncoder.elm
+++ b/test/CommentEncoder.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 encodeComment : Comment -> Json.Encode.Value

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 encodeComment : Comment -> Json.Encode.Value

--- a/test/CommentType.elm
+++ b/test/CommentType.elm
@@ -1,4 +1,8 @@
-module Main exposing (..)
+module CommentType exposing (..)
+
+
+import Date exposing (Date)
+import Dict exposing (Dict)
 
 
 type alias Comment =

--- a/test/CommentType.elm
+++ b/test/CommentType.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 type alias Comment =

--- a/test/CommentTypeWithOptions.elm
+++ b/test/CommentTypeWithOptions.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 type alias Comment =

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -134,7 +134,7 @@ shouldMatchEncoderSource options x =
   shouldMatchFile . printf outputWrapping $ toElmEncoderSourceWith options x
 
 outputWrapping :: String
-outputWrapping = "module Main (..) where\n\n\n%s\n"
+outputWrapping = "module Main exposing (..)\n\n\n%s\n"
 
 shouldMatchFile :: String -> FilePath -> IO ()
 shouldMatchFile actual fileExpected =

--- a/test/PositionDecoder.elm
+++ b/test/PositionDecoder.elm
@@ -1,0 +1,14 @@
+module Main exposing (..)
+
+
+fromStringPosition : String -> Result String Position
+fromStringPosition string = 
+    case string of
+        "Beginning" -> Result.Ok Beginning
+        "End" -> Result.Ok End
+        "Middle" -> Result.Ok Middle
+        _ -> Result.Err ("Not valid pattern for decoder to Position. Pattern: " ++ (toString string))
+
+decodePosition : Json.Decode.Decoder Position
+decodePosition =
+    Json.Decode.string `Json.Decode.andThen` fromStringPosition

--- a/test/PositionType.elm
+++ b/test/PositionType.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 type Position

--- a/test/PostDecoder.elm
+++ b/test/PostDecoder.elm
@@ -1,6 +1,9 @@
 module Main exposing (..)
 
 
+import Json.Decode
+
+
 decodePost : Json.Decode.Decoder Post
 decodePost =
   Json.Decode.succeed Post

--- a/test/PostDecoder.elm
+++ b/test/PostDecoder.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 decodePost : Json.Decode.Decoder Post

--- a/test/PostDecoderWithOptions.elm
+++ b/test/PostDecoderWithOptions.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 decodePost : Json.Decode.Decoder Post

--- a/test/PostEncoder.elm
+++ b/test/PostEncoder.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 encodePost : Post -> Json.Encode.Value

--- a/test/PostEncoderWithOptions.elm
+++ b/test/PostEncoderWithOptions.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 encodePost : Post -> Json.Encode.Value

--- a/test/PostType.elm
+++ b/test/PostType.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 type alias Post =

--- a/test/PostTypeWithOptions.elm
+++ b/test/PostTypeWithOptions.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 
 type alias Post =


### PR DESCRIPTION
The module header syntax has changed from Elm 0.16 to 0.17: module Main (..) where -> module Main exposing (..)