### PR TITLE
Added ElmType Instances to Int8-Int64

### DIFF
--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TypeOperators       #-}
 module Elm.Type where
 
+import           Data.Int (Int8, Int16, Int32, Int64)
 import           Data.Map
 import           Data.Proxy
 import           Data.Text
@@ -60,6 +61,18 @@ instance ElmType Int where
     toElmType _ = Primitive "Int"
 
 instance ElmType Integer where
+    toElmType _ = Primitive "Int"
+
+instance ElmType Int8 where
+    toElmType _ = Primitive "Int"
+
+instance ElmType Int16 where
+    toElmType _ = Primitive "Int"
+
+instance ElmType Int32 where
+    toElmType _ = Primitive "Int"
+
+instance ElmType Int64 where
     toElmType _ = Primitive "Int"
 
 instance (ElmType a,ElmType b) => ElmType (a,b) where


### PR DESCRIPTION
Added `ElmType` instances for `Data.Int.Int8`, `Int16`, `Int32`, and `Int64` (`Int64` in particular being used for PostgreSQL ids in Opaleye).