### PR TITLE
Fix the tests on rework-adt

### DIFF
--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -17,6 +17,8 @@ instance HasType ElmDatatype where
         sformat ("type " % stext % cr % "    = " % stext) typeName <$> render constructor
     render (ElmDatatype typeName constructor@(NamedConstructor _ _)) =
         sformat ("type " % stext % cr % "    = " % stext) typeName <$> render constructor
+    render (ElmDatatype typeName constructor@(NamedEmptyConstructor _ )) =
+        sformat ("type " % stext % cr % "    = " % stext) typeName <$> render constructor
     render (ElmPrimitive primitive) = render primitive
 
 
@@ -25,6 +27,8 @@ instance HasType ElmConstructor where
         sformat ("    { " % stext % cr % "    }") <$> render value
     render (NamedConstructor constructorName value) =
         sformat (stext % " " % stext) constructorName <$> render value
+    render (NamedEmptyConstructor constructorName ) =
+        pure constructorName
     render (MultipleConstructors constructors) =
         fmap (Data.Text.intercalate "\n    | ") $ sequence $ render <$> constructors
 

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -41,6 +41,7 @@ data ElmPrimitive
 data ElmConstructor
     = NamedConstructor Text
                        ElmValue
+    | NamedEmptyConstructor Text
     | RecordConstructor Text
                         ElmValue
     | MultipleConstructors [ElmConstructor]
@@ -78,12 +79,19 @@ instance (Datatype d, GenericElmConstructor f) =>
 class GenericElmConstructor f  where
     genericToElmConstructor :: f a -> ElmConstructor
 
-instance (Constructor c, GenericElmValue f) =>
+instance {-# OVERLAPPABLE #-} (Constructor c, GenericElmValue f) =>
          GenericElmConstructor (C1 c f) where
     genericToElmConstructor constructor =
         if conIsRecord constructor
             then RecordConstructor name (genericToElmValue (unM1 constructor))
             else NamedConstructor name (genericToElmValue (unM1 constructor))
+      where
+        name = pack $ conName constructor
+
+instance {-# OVERLAPPING #-} (Constructor c) =>
+         GenericElmConstructor (C1 c U1) where
+    genericToElmConstructor constructor =
+        NamedEmptyConstructor name
       where
         name = pack $ conName constructor
 

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures    #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
@@ -115,7 +117,11 @@ instance {-# OVERLAPPABLE #-} (Selector s, GenericElmValue a) =>
             (genericToElmValue (undefined :: a p))
 
 instance {-# OVERLAPPING #-} (GenericElmValue a) =>
+#if __GLASGOW_HASKELL__ >= 800
+         GenericElmValue (S1 ('MetaSel 'Nothing su ss ds) a) where
+#else
          GenericElmValue (S1 NoSelector a) where
+#endif
     genericToElmValue _ =
         genericToElmValue (undefined :: a p)
 

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -99,12 +99,17 @@ instance (GenericElmConstructor f, GenericElmConstructor g) =>
 class GenericElmValue f  where
     genericToElmValue :: f a -> ElmValue
 
-instance (Selector s, GenericElmValue a) =>
+instance {-# OVERLAPPABLE #-} (Selector s, GenericElmValue a) =>
          GenericElmValue (S1 s a) where
     genericToElmValue selector =
         ElmField
             (pack (selName selector))
             (genericToElmValue (undefined :: a p))
+
+instance {-# OVERLAPPING #-} (GenericElmValue a) =>
+         GenericElmValue (S1 NoSelector a) where
+    genericToElmValue _ =
+        genericToElmValue (undefined :: a p)
 
 instance (GenericElmValue f, GenericElmValue g) =>
          GenericElmValue (f :*: g) where
@@ -122,6 +127,8 @@ instance ElmType a =>
         case toElmType (undefined :: a) of
             ElmPrimitive primitive -> ElmPrimitiveRef primitive
             ElmDatatype name _ -> ElmRef name
+
+------------------------------------------------------------
 
 instance ElmType a => ElmType [a] where
     toElmType _ = ElmPrimitive (EList (toElmType (undefined :: a)))


### PR DESCRIPTION
Before these changes, we had:

```haskell
*> toElmType (Proxy :: Proxy Timing)
ElmDatatype "Timing"
    (MultipleConstructors
        [ NamedConstructor "Start" (ElmPrimitiveRef EUnit)
        , MultipleConstructors [ NamedConstructor "Continue" (ElmField "" (ElmPrimitiveRef EFloat))
                               , NamedConstructor "Stop" (ElmPrimitiveRef EUnit)
                               ]])
*> toElmTypeSource (Proxy :: Proxy Timing)
"type Timing\n    = Start ()\n    | Continue  : Float\n    | Stop ()"
```

After this change:

```haskell
*> toElmType (Proxy :: Proxy Timing)
ElmDatatype "Timing"
    (MultipleConstructors
        [ NamedEmptyConstructor "Start"
        , MultipleConstructors [ NamedConstructor "Continue" (ElmPrimitiveRef EFloat)
                               , NamedEmptyConstructor "Stop"
                               ]])
*> toElmTypeSource (Proxy :: Proxy Timing)
"type Timing\n    = Start\n    | Continue Float\n    | Stop"
```

Any pointers for how to achieve this without overlapping instances would be much appreciated :)