### PR TITLE
API for rendering type/encoder/decoder references.

### DIFF
--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Elm.Common  where
 
-import           Data.Text
+import           Data.Monoid
+import           Data.Text              (Text)
+import           Data.Text.Lazy         (count)
+import           Data.Text.Lazy.Builder
 import           Formatting
 
 data Options =
@@ -12,3 +15,10 @@ defaultOptions = Options {fieldLabelModifier = id}
 
 cr :: Format r r
 cr = now "\n"
+
+parenthesize :: Format r (Builder -> r)
+parenthesize =
+  later (\t ->
+           if count " " (toLazyText t) > 0
+              then singleton '(' <> t <> singleton ')'
+              else t)

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -32,7 +32,7 @@ instance HasDecoder ElmDatatype where
             name
             fnName <$>
             render constructor
-    render (ElmPrimitive primitive) = render primitive
+    render (ElmPrimitive primitive) = renderRef primitive
 
 instance HasDecoderRef ElmDatatype where
     renderRef (ElmDatatype name _) =
@@ -51,7 +51,7 @@ instance HasDecoder ElmConstructor where
 
 instance HasDecoder ElmValue where
     render (ElmRef name) = pure (sformat ("decode" % stext) name)
-    render (ElmPrimitiveRef primitive) = render primitive
+    render (ElmPrimitiveRef primitive) = renderRef primitive
     render (Values x y) = sformat (stext % cr % stext) <$> render x <*> render y
     render (ElmField name value) = do
         fieldModifier <- asks fieldLabelModifier
@@ -61,28 +61,25 @@ instance HasDecoder ElmValue where
             render value
 
 
-instance HasDecoder ElmPrimitive where
-    render (EList (ElmPrimitive EChar)) = pure "string"
-    render (EList datatype) =
-        sformat ("(list " % stext % ")") <$> renderRef datatype
-    render (EDict key value) =
-        sformat ("(map Dict.fromList " % stext % ")") <$>
-        render (EList (ElmPrimitive (ETuple2 (ElmPrimitive key) value)))
-    render (EMaybe datatype) =
-        sformat ("(maybe " % stext % ")") <$> renderRef datatype
-    render (ETuple2 x y) =
-        sformat ("(tuple2 (,) " % stext % " " % stext % ")") <$> render x <*>
-        render y
-    render EUnit = pure "(succeed ())"
-    render EDate = pure "(customDecoder string Date.fromString)"
-    render EInt = pure "int"
-    render EBool = pure "bool"
-    render EChar = pure "char"
-    render EFloat = pure "float"
-    render EString = pure "string"
-
 instance HasDecoderRef ElmPrimitive where
-    renderRef = render
+    renderRef (EList (ElmPrimitive EChar)) = pure "string"
+    renderRef (EList datatype) =
+        sformat ("(list " % stext % ")") <$> renderRef datatype
+    renderRef (EDict key value) =
+        sformat ("(map Dict.fromList " % stext % ")") <$>
+        renderRef (EList (ElmPrimitive (ETuple2 (ElmPrimitive key) value)))
+    renderRef (EMaybe datatype) =
+        sformat ("(maybe " % stext % ")") <$> renderRef datatype
+    renderRef (ETuple2 x y) =
+        sformat ("(tuple2 (,) " % stext % " " % stext % ")") <$> renderRef x <*>
+        renderRef y
+    renderRef EUnit = pure "(succeed ())"
+    renderRef EDate = pure "(customDecoder string Date.fromString)"
+    renderRef EInt = pure "int"
+    renderRef EBool = pure "bool"
+    renderRef EChar = pure "char"
+    renderRef EFloat = pure "float"
+    renderRef EString = pure "string"
 
 
 toElmDecoderRefWith :: ElmType a => Options -> a -> Text

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -22,7 +22,7 @@ instance HasEncoder ElmDatatype where
     render d@(ElmDatatype name constructor) = do
         fnName <- renderRef d
         sformat
-            (stext % " : " % stext % " -> Value" % cr % stext % " x =" % stext)
+            (stext % " : " % stext % " -> Json.Encode.Value" % cr % stext % " x =" % stext)
             fnName
             name
             fnName <$>
@@ -38,7 +38,7 @@ instance HasEncoderRef ElmDatatype where
 
 instance HasEncoder ElmConstructor where
     render (RecordConstructor _ value) =
-      sformat (cr % "    object" % cr % "        [ " % stext % cr % "        ]") <$> render value
+      sformat (cr % "    Json.Encode.object" % cr % "        [ " % stext % cr % "        ]") <$> render value
 
 instance HasEncoder ElmValue where
     render (ElmField name value) = do
@@ -55,17 +55,17 @@ instance HasEncoder ElmValue where
     render (Values x y) = sformat (stext % cr % "        , " % stext) <$> render x <*> render y
 
 instance HasEncoderRef ElmPrimitive where
-    renderRef EDate = pure "(string << toISOString)"
-    renderRef EUnit = pure "null"
-    renderRef EInt = pure "int"
-    renderRef EChar = pure "char"
-    renderRef EBool = pure "bool"
-    renderRef EFloat = pure "float"
-    renderRef EString = pure "string"
-    renderRef (EList (ElmPrimitive EChar)) = pure "string"
-    renderRef (EList datatype) = sformat ("(list << List.map " % stext % ")") <$> renderRef datatype
+    renderRef EDate = pure "(Json.Encode.string << toISOString)"
+    renderRef EUnit = pure "Json.Encode.null"
+    renderRef EInt = pure "Json.Encode.int"
+    renderRef EChar = pure "Json.Encode.char"
+    renderRef EBool = pure "Json.Encode.bool"
+    renderRef EFloat = pure "Json.Encode.float"
+    renderRef EString = pure "Json.Encode.string"
+    renderRef (EList (ElmPrimitive EChar)) = pure "Json.Encode.string"
+    renderRef (EList datatype) = sformat ("(Json.Encode.list << List.map " % stext % ")") <$> renderRef datatype
     renderRef (EMaybe datatype) =
-        sformat ("(Maybe.withDefault null << Maybe.map " % stext % ")") <$>
+        sformat ("(Maybe.withDefault Json.Encode.null << Maybe.map " % stext % ")") <$>
         renderRef datatype
     renderRef (ETuple2 x y) =
         sformat ("(tuple2 " % stext % " " % stext % ")") <$> renderRef x <*>

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -42,15 +42,15 @@ instance HasType ElmValue where
 
 instance HasType ElmPrimitive where
     render (EList (ElmPrimitive EChar)) = render EString
-    render (EList (ElmPrimitive value)) = sformat ("List " % stext) <$> render value
-    render (EList (ElmDatatype name _)) = pure $ sformat ("List " % stext) name
+    render (EList (ElmPrimitive value)) = sformat ("List " % (parenthesize %. stext)) <$> render value
+    render (EList (ElmDatatype name _)) = pure $ sformat ("List " % (parenthesize %. stext)) name
     render (ETuple2 x y) =
         sformat ("( " % stext % ", " % stext % " )") <$> render x <*> render y
-    render (EMaybe (ElmDatatype name _)) = pure $ sformat ("Maybe " % stext) name
+    render (EMaybe (ElmDatatype name _)) = pure $ sformat ("Maybe " % (parenthesize %. stext)) name
     render (EMaybe (ElmPrimitive value)) =
-        sformat ("Maybe " % stext) <$> render value
+        sformat ("Maybe " % (parenthesize %. stext)) <$> render value
     render (EDict k v) =
-        sformat ("Dict " % stext % " " % stext) <$> render k <*> render v
+        sformat ("Dict " % (parenthesize %. stext) % " " % (parenthesize %. stext)) <$> render k <*> render v
     render EInt = pure "Int"
     render EDate = pure "Date"
     render EBool = pure "Bool"

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -19,12 +19,12 @@ class HasTypeRef a where
   renderRef :: a -> Reader Options Text
 
 instance HasType ElmDatatype where
-    render (ElmDatatype typeName constructor@(RecordConstructor _ _)) =
-        sformat ("type alias " % stext % " =" % cr % stext) typeName <$> render constructor
-    render (ElmDatatype typeName constructor@(MultipleConstructors _)) =
-        sformat ("type " % stext % cr % "    = " % stext) typeName <$> render constructor
-    render (ElmDatatype typeName constructor@(NamedConstructor _ _)) =
-        sformat ("type " % stext % cr % "    = " % stext) typeName <$> render constructor
+    render d@(ElmDatatype _ constructor@(RecordConstructor _ _)) =
+        sformat ("type alias " % stext % " =" % cr % stext) <$> renderRef d <*> render constructor
+    render d@(ElmDatatype _ constructor@(MultipleConstructors _)) =
+        sformat ("type " % stext % cr % "    = " % stext) <$> renderRef d <*> render constructor
+    render d@(ElmDatatype _ constructor@(NamedConstructor _ _)) =
+        sformat ("type " % stext % cr % "    = " % stext) <$> renderRef d <*> render constructor
     render (ElmPrimitive primitive) = render primitive
 
 instance HasTypeRef ElmDatatype where
@@ -57,13 +57,11 @@ instance HasType ElmValue where
 
 instance HasType ElmPrimitive where
     render (EList (ElmPrimitive EChar)) = render EString
-    render (EList (ElmPrimitive value)) = sformat ("List " % (parenthesize %. stext)) <$> render value
-    render (EList (ElmDatatype name _)) = pure $ sformat ("List " % (parenthesize %. stext)) name
+    render (EList datatype) = sformat ("List " % (parenthesize %. stext)) <$> renderRef datatype
     render (ETuple2 x y) =
         sformat ("( " % stext % ", " % stext % " )") <$> render x <*> render y
-    render (EMaybe (ElmDatatype name _)) = pure $ sformat ("Maybe " % (parenthesize %. stext)) name
-    render (EMaybe (ElmPrimitive value)) =
-        sformat ("Maybe " % (parenthesize %. stext)) <$> render value
+    render (EMaybe datatype) =
+        sformat ("Maybe " % (parenthesize %. stext)) <$> renderRef datatype
     render (EDict k v) =
         sformat ("Dict " % (parenthesize %. stext) % " " % (parenthesize %. stext)) <$> render k <*> render v
     render EInt = pure "Int"

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -25,7 +25,7 @@ instance HasType ElmDatatype where
         sformat ("type " % stext % cr % "    = " % stext) <$> renderRef d <*> render constructor
     render d@(ElmDatatype _ constructor@(NamedConstructor _ _)) =
         sformat ("type " % stext % cr % "    = " % stext) <$> renderRef d <*> render constructor
-    render (ElmPrimitive primitive) = render primitive
+    render (ElmPrimitive primitive) = renderRef primitive
 
 instance HasTypeRef ElmDatatype where
     renderRef (ElmDatatype typeName _) =
@@ -49,31 +49,28 @@ instance HasType ElmValue where
     render ElmEmpty = pure ""
     render (Values x y) =
         sformat (stext % cr % "    , " % stext) <$> render x <*> render y
-    render (ElmPrimitiveRef primitive) = sformat (" " % stext) <$> render primitive
+    render (ElmPrimitiveRef primitive) = sformat (" " % stext) <$> renderRef primitive
     render (ElmField name value) = do
         fieldModifier <- asks fieldLabelModifier
         sformat (stext % " :" % stext) (fieldModifier name) <$> render value
 
 
-instance HasType ElmPrimitive where
-    render (EList (ElmPrimitive EChar)) = render EString
-    render (EList datatype) = sformat ("List " % (parenthesize %. stext)) <$> renderRef datatype
-    render (ETuple2 x y) =
-        sformat ("( " % stext % ", " % stext % " )") <$> render x <*> render y
-    render (EMaybe datatype) =
-        sformat ("Maybe " % (parenthesize %. stext)) <$> renderRef datatype
-    render (EDict k v) =
-        sformat ("Dict " % (parenthesize %. stext) % " " % (parenthesize %. stext)) <$> render k <*> render v
-    render EInt = pure "Int"
-    render EDate = pure "Date"
-    render EBool = pure "Bool"
-    render EChar = pure "Char"
-    render EString = pure "String"
-    render EUnit = pure "()"
-    render EFloat = pure "Float"
-
 instance HasTypeRef ElmPrimitive where
-    renderRef = render
+    renderRef (EList (ElmPrimitive EChar)) = renderRef EString
+    renderRef (EList datatype) = sformat ("List " % (parenthesize %. stext)) <$> renderRef datatype
+    renderRef (ETuple2 x y) =
+        sformat ("( " % stext % ", " % stext % " )") <$> renderRef x <*> renderRef y
+    renderRef (EMaybe datatype) =
+        sformat ("Maybe " % (parenthesize %. stext)) <$> renderRef datatype
+    renderRef (EDict k v) =
+        sformat ("Dict " % (parenthesize %. stext) % " " % (parenthesize %. stext)) <$> renderRef k <*> renderRef v
+    renderRef EInt = pure "Int"
+    renderRef EDate = pure "Date"
+    renderRef EBool = pure "Bool"
+    renderRef EChar = pure "Char"
+    renderRef EString = pure "String"
+    renderRef EUnit = pure "()"
+    renderRef EFloat = pure "Float"
 
 toElmTypeRefWith :: ElmType a => Options -> a -> Text
 toElmTypeRefWith options x = runReader (renderRef (toElmType x)) options

--- a/test/CommentEncoder.elm
+++ b/test/CommentEncoder.elm
@@ -3,16 +3,16 @@ module CommentEncoder exposing (..)
 import CommentType exposing (..)
 import Exts.Date exposing (..)
 import Exts.Json.Encode exposing (..)
-import Json.Encode exposing (..)
+import Json.Encode
 
 
-encodeComment : Comment -> Value
+encodeComment : Comment -> Json.Encode.Value
 encodeComment x =
-    object
-        [ ( "postId", int x.postId )
-        , ( "text", string x.text )
-        , ( "mainCategories", (tuple2 string string) x.mainCategories )
-        , ( "published", bool x.published )
-        , ( "created", (string << toISOString) x.created )
-        , ( "tags", (dict string int) x.tags )
+    Json.Encode.object
+        [ ( "postId", Json.Encode.int x.postId )
+        , ( "text", Json.Encode.string x.text )
+        , ( "mainCategories", (tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
+        , ( "published", Json.Encode.bool x.published )
+        , ( "created", (Json.Encode.string << toISOString) x.created )
+        , ( "tags", (dict Json.Encode.string Json.Encode.int) x.tags )
         ]

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -3,16 +3,16 @@ module CommentEncoderWithOptions exposing (..)
 import CommentType exposing (..)
 import Exts.Date exposing (..)
 import Exts.Json.Encode exposing (..)
-import Json.Encode exposing (..)
+import Json.Encode
 
 
-encodeComment : Comment -> Value
+encodeComment : Comment -> Json.Encode.Value
 encodeComment x =
-    object
-        [ ( "commentPostId", int x.postId )
-        , ( "commentText", string x.text )
-        , ( "commentMainCategories", (tuple2 string string) x.mainCategories )
-        , ( "commentPublished", bool x.published )
-        , ( "commentCreated", (string << toISOString) x.created )
-        , ( "commentTags", (dict string int) x.tags )
+    Json.Encode.object
+        [ ( "commentPostId", Json.Encode.int x.postId )
+        , ( "commentText", Json.Encode.string x.text )
+        , ( "commentMainCategories", (tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
+        , ( "commentPublished", Json.Encode.bool x.published )
+        , ( "commentCreated", (Json.Encode.string << toISOString) x.created )
+        , ( "commentTags", (dict Json.Encode.string Json.Encode.int) x.tags )
         ]

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -244,7 +244,7 @@ toElmEncoderSpec =
                   ,"import CommentType exposing (..)"
                   ,"import Exts.Date exposing (..)"
                   ,"import Exts.Json.Encode exposing (..)"
-                  ,"import Json.Encode exposing (..)"
+                  ,"import Json.Encode"
                   ,""
                   ,""
                   ,"%s"])
@@ -256,7 +256,7 @@ toElmEncoderSpec =
          (unlines ["module PostEncoder exposing (..)"
                   ,""
                   ,"import CommentEncoder exposing (..)"
-                  ,"import Json.Encode exposing (..)"
+                  ,"import Json.Encode"
                   ,"import PostType exposing (..)"
                   ,""
                   ,""
@@ -271,7 +271,7 @@ toElmEncoderSpec =
                   ,"import CommentType exposing (..)"
                   ,"import Exts.Date exposing (..)"
                   ,"import Exts.Json.Encode exposing (..)"
-                  ,"import Json.Encode exposing (..)"
+                  ,"import Json.Encode"
                   ,""
                   ,""
                   ,"%s"])
@@ -283,7 +283,7 @@ toElmEncoderSpec =
          (unlines ["module PostEncoderWithOptions exposing (..)"
                   ,""
                   ,"import CommentEncoder exposing (..)"
-                  ,"import Json.Encode exposing (..)"
+                  ,"import Json.Encode"
                   ,"import PostType exposing (..)"
                   ,""
                   ,""
@@ -297,19 +297,19 @@ toElmEncoderSpec =
             `shouldBe` "encodePost"
           it "toElmEncoderRef [Comment]" $
             toElmEncoderRef (Proxy :: Proxy [Comment])
-            `shouldBe` "(list << List.map encodeComment)"
+            `shouldBe` "(Json.Encode.list << List.map encodeComment)"
           it "toElmEncoderRef String" $
             toElmEncoderRef (Proxy :: Proxy String)
-            `shouldBe` "string"
+            `shouldBe` "Json.Encode.string"
           it "toElmEncoderRef (Maybe String)" $
             toElmEncoderRef (Proxy :: Proxy (Maybe String))
-            `shouldBe` "(Maybe.withDefault null << Maybe.map string)"
+            `shouldBe` "(Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string)"
           it "toElmEncoderRef [Maybe String]" $
             toElmEncoderRef (Proxy :: Proxy [Maybe String])
-            `shouldBe` "(list << List.map (Maybe.withDefault null << Maybe.map string))"
+            `shouldBe` "(Json.Encode.list << List.map (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
           it "toElmEncoderRef (Map String (Maybe String))" $
             toElmEncoderRef (Proxy :: Proxy (Map String (Maybe String)))
-            `shouldBe` "(dict string (Maybe.withDefault null << Maybe.map string))"
+            `shouldBe` "(dict Json.Encode.string (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
 
 shouldMatchTypeSource
   :: ElmType a

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -51,6 +51,10 @@ data Timing
   | Stop
   deriving (Generic,ElmType)
 
+newtype FavoritePlaces =
+  FavoritePlaces {positionsByUser :: Map String [Position]}
+  deriving (Generic,ElmType)
+
 spec :: Hspec.Spec
 spec =
   do toElmTypeSpec
@@ -95,6 +99,17 @@ toElmTypeSpec =
          defaultOptions
          (Proxy :: Proxy Timing)
          "test/TimingType.elm"
+     it "toElmTypeSource FavoritePlaces" $
+       shouldMatchTypeSource
+         (unlines ["module FavoritePlacesType exposing (..)"
+                  ,""
+                  ,"import PositionType exposing (..)"
+                  ,""
+                  ,""
+                  ,"%s"])
+         defaultOptions
+         (Proxy :: Proxy FavoritePlaces)
+         "test/FavoritePlacesType.elm"
      it "toElmTypeSourceWithOptions Post" $
        shouldMatchTypeSource
          (unlines ["module PostTypeWithOptions exposing (..)"

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -133,6 +133,25 @@ toElmTypeSpec =
          (defaultOptions {fieldLabelModifier = withPrefix "comment"})
          (Proxy :: Proxy Comment)
          "test/CommentTypeWithOptions.elm"
+     describe "Convert to Elm type references." $
+       do it "toElmTypeRef Post" $
+            toElmTypeRef (Proxy :: Proxy Post)
+            `shouldBe` "Post"
+          it "toElmTypeRef [Comment]" $
+            toElmTypeRef (Proxy :: Proxy [Comment])
+            `shouldBe` "List Comment"
+          it "toElmTypeRef String" $
+            toElmTypeRef (Proxy :: Proxy String)
+            `shouldBe` "String"
+          it "toElmTypeRef (Maybe String)" $
+            toElmTypeRef (Proxy :: Proxy (Maybe String))
+            `shouldBe` "Maybe String"
+          it "toElmTypeRef [Maybe String]" $
+            toElmTypeRef (Proxy :: Proxy [Maybe String])
+            `shouldBe` "List (Maybe String)"
+          it "toElmTypeRef (Map String (Maybe String))" $
+            toElmTypeRef (Proxy :: Proxy (Map String (Maybe String)))
+            `shouldBe` "Dict String (Maybe String)"
 
 toElmDecoderSpec :: Hspec.Spec
 toElmDecoderSpec =
@@ -195,6 +214,25 @@ toElmDecoderSpec =
          (defaultOptions {fieldLabelModifier = withPrefix "comment"})
          (Proxy :: Proxy Comment)
          "test/CommentDecoderWithOptions.elm"
+     describe "Convert to Elm decoder references." $
+       do it "toElmDecoderRef Post" $
+            toElmDecoderRef (Proxy :: Proxy Post)
+            `shouldBe` "decodePost"
+          it "toElmDecoderRef [Comment]" $
+            toElmDecoderRef (Proxy :: Proxy [Comment])
+            `shouldBe` "(list decodeComment)"
+          it "toElmDecoderRef String" $
+            toElmDecoderRef (Proxy :: Proxy String)
+            `shouldBe` "string"
+          it "toElmDecoderRef (Maybe String)" $
+            toElmDecoderRef (Proxy :: Proxy (Maybe String))
+            `shouldBe` "(maybe string)"
+          it "toElmDecoderRef [Maybe String]" $
+            toElmDecoderRef (Proxy :: Proxy [Maybe String])
+            `shouldBe` "(list (maybe string))"
+          it "toElmDecoderRef (Map String (Maybe String))" $
+            toElmDecoderRef (Proxy :: Proxy (Map String (Maybe String)))
+            `shouldBe` "(map Dict.fromList (list (tuple2 (,) string (maybe string))))"
 
 toElmEncoderSpec :: Hspec.Spec
 toElmEncoderSpec =
@@ -253,6 +291,25 @@ toElmEncoderSpec =
          (defaultOptions {fieldLabelModifier = withPrefix "post"})
          (Proxy :: Proxy Post)
          "test/PostEncoderWithOptions.elm"
+     describe "Convert to Elm encoder references." $
+       do it "toElmEncoderRef Post" $
+            toElmEncoderRef (Proxy :: Proxy Post)
+            `shouldBe` "encodePost"
+          it "toElmEncoderRef [Comment]" $
+            toElmEncoderRef (Proxy :: Proxy [Comment])
+            `shouldBe` "(list << List.map encodeComment)"
+          it "toElmEncoderRef String" $
+            toElmEncoderRef (Proxy :: Proxy String)
+            `shouldBe` "string"
+          it "toElmEncoderRef (Maybe String)" $
+            toElmEncoderRef (Proxy :: Proxy (Maybe String))
+            `shouldBe` "(Maybe.withDefault null << Maybe.map string)"
+          it "toElmEncoderRef [Maybe String]" $
+            toElmEncoderRef (Proxy :: Proxy [Maybe String])
+            `shouldBe` "(list << List.map (Maybe.withDefault null << Maybe.map string))"
+          it "toElmEncoderRef (Map String (Maybe String))" $
+            toElmEncoderRef (Proxy :: Proxy (Map String (Maybe String)))
+            `shouldBe` "(dict string (Maybe.withDefault null << Maybe.map string))"
 
 shouldMatchTypeSource
   :: ElmType a

--- a/test/FavoritePlacesType.elm
+++ b/test/FavoritePlacesType.elm
@@ -1,0 +1,8 @@
+module FavoritePlacesType exposing (..)
+
+import PositionType exposing (..)
+
+
+type alias FavoritePlaces =
+    { positionsByUser : Dict String (List Position)
+    }

--- a/test/PostEncoder.elm
+++ b/test/PostEncoder.elm
@@ -1,17 +1,17 @@
 module PostEncoder exposing (..)
 
 import CommentEncoder exposing (..)
-import Json.Encode exposing (..)
+import Json.Encode
 import PostType exposing (..)
 
 
-encodePost : Post -> Value
+encodePost : Post -> Json.Encode.Value
 encodePost x =
-    object
-        [ ( "id", int x.id )
-        , ( "name", string x.name )
-        , ( "age", (Maybe.withDefault null << Maybe.map float) x.age )
-        , ( "comments", (list << List.map encodeComment) x.comments )
-        , ( "promoted", (Maybe.withDefault null << Maybe.map encodeComment) x.promoted )
-        , ( "author", (Maybe.withDefault null << Maybe.map string) x.author )
+    Json.Encode.object
+        [ ( "id", Json.Encode.int x.id )
+        , ( "name", Json.Encode.string x.name )
+        , ( "age", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.float) x.age )
+        , ( "comments", (Json.Encode.list << List.map encodeComment) x.comments )
+        , ( "promoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.promoted )
+        , ( "author", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.author )
         ]

--- a/test/PostEncoderWithOptions.elm
+++ b/test/PostEncoderWithOptions.elm
@@ -1,17 +1,17 @@
 module PostEncoderWithOptions exposing (..)
 
 import CommentEncoder exposing (..)
-import Json.Encode exposing (..)
+import Json.Encode
 import PostType exposing (..)
 
 
-encodePost : Post -> Value
+encodePost : Post -> Json.Encode.Value
 encodePost x =
-    object
-        [ ( "postId", int x.id )
-        , ( "postName", string x.name )
-        , ( "postAge", (Maybe.withDefault null << Maybe.map float) x.age )
-        , ( "postComments", (list << List.map encodeComment) x.comments )
-        , ( "postPromoted", (Maybe.withDefault null << Maybe.map encodeComment) x.promoted )
-        , ( "postAuthor", (Maybe.withDefault null << Maybe.map string) x.author )
+    Json.Encode.object
+        [ ( "postId", Json.Encode.int x.id )
+        , ( "postName", Json.Encode.string x.name )
+        , ( "postAge", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.float) x.age )
+        , ( "postComments", (Json.Encode.list << List.map encodeComment) x.comments )
+        , ( "postPromoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.promoted )
+        , ( "postAuthor", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.author )
         ]


### PR DESCRIPTION
This PR includes:
1. A small fix to parenthesise types when required.
2. A new API (`toElmTypeRef`, etc.), which makes it possible for downstream libraries to generate code using the types, encoders and decoders generated by `elm-export` (following on from #4).
3. Some simplifications to the code enabled by the new `renderRef` functions.
4. Re-introducing qualified imports for `Json.Encode`.

Re: 3, if you don't like the simplifications I can take them out.

Re: 4, qualifying the `Json.Encode` functions is necessary for generating functions like:

``` elm
postData :: List String -> Task Http.Error (List String)
```

Here we need to encode the `List String` for the request body and decode the `List String` in the response in the same function.
