### PR TITLE
Remove ElmType instances of non-32bit int types

### DIFF
--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -8,7 +8,7 @@
 
 module Elm.Type where
 
-import           Data.Int     (Int16, Int32, Int64, Int8)
+import           Data.Int     (Int32)
 import           Data.Map
 import           Data.Proxy
 import           Data.Text
@@ -59,22 +59,7 @@ instance ElmType Day where
 instance ElmType Double where
     toElmType _ = Primitive "Float"
 
-instance ElmType Int where
-    toElmType _ = Primitive "Int"
-
-instance ElmType Integer where
-    toElmType _ = Primitive "Int"
-
-instance ElmType Int8 where
-    toElmType _ = Primitive "Int"
-
-instance ElmType Int16 where
-    toElmType _ = Primitive "Int"
-
 instance ElmType Int32 where
-    toElmType _ = Primitive "Int"
-
-instance ElmType Int64 where
     toElmType _ = Primitive "Int"
 
 instance (ElmType a, ElmType b) =>

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -5,6 +5,7 @@
 module ExportSpec where
 
 import           Data.Char
+import           Data.Int
 import           Data.Map
 import           Data.Monoid
 import           Data.Proxy
@@ -17,7 +18,7 @@ import           Test.Hspec   as Hspec
 import           Text.Printf
 
 data Post =
-  Post {id       :: Int
+  Post {id       :: Int32
        ,name     :: String
        ,age      :: Maybe Double
        ,comments :: [Comment]
@@ -26,12 +27,12 @@ data Post =
   deriving (Generic,ElmType)
 
 data Comment =
-  Comment {postId         :: Int
+  Comment {postId         :: Int32
           ,text           :: Text
           ,mainCategories :: (String,String)
           ,published      :: Bool
           ,created        :: UTCTime
-          ,tags           :: Map String Int}
+          ,tags           :: Map String Int32}
   deriving (Generic,ElmType)
 
 data Position


### PR DESCRIPTION
As requested, here's this change with a more thorough explanation. 

Elm's `Int` type is a 32bit two's complement integer. The exact size of
Haskell's `Int` type is unspecified. Having instances for integral types
which don't have an isomorphism to Elm types allows for lossy
conversions when moving data between the two languages. For example
sending an Elm Int to a Haskell function with type `Int8 -> Int8` will
only work with 8 bit values and raise an error for any out of range
values. By only providing instances for Int32 the user is forced into
being more careful with how they marshall integer types between Haskell
and Elm.

See https://github.com/elm-lang/core/issues/742#issuecomment-257484290
for information on the specifics of Elm's Int type.