### PR TITLE
Support GHC 8

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -30,4 +30,4 @@ extra-package-dbs: []
 # Extra directories used by stack for building
 # extra-include-dirs: [/path/to/dir]
 # extra-lib-dirs: [/path/to/dir]
-pvp-bounds: both
+pvp-bounds: lower


### PR DESCRIPTION
It looks like stack is adding some restrictive upper bounds which is preventing elm-export from working on GHC8:

http://packdeps.haskellers.com/feed?needle=elm-export

I've tested it without the restrictive upper bounds and it works fine.

This PR should work if I'm reading the stack docs correctly.