### PR TITLE
Hit it with the Haskell hammer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,9 @@ import Elm
 
 spec :: Spec
 spec =
-  Spec
-    ["Db", "Types"]
-    [ "import Json.Decode exposing (..)"
-    , "import Json.Decode.Pipeline exposing (..)"
-    , toElmTypeSource (Proxy :: Proxy Person)
-    , toElmDecoderSource (Proxy :: Proxy Person)
-    ]
+  moduleSpec ["Db", "Types"] $ do
+    renderType (Proxy :: Proxy Person)
+    renderDecoder (Proxy :: Proxy Person)
 
 main :: IO ()
 main = specsToDir [spec] "some/where/output"

--- a/test/CommentEncoder.elm
+++ b/test/CommentEncoder.elm
@@ -10,8 +10,8 @@ encodeComment x =
     Json.Encode.object
         [ ( "postId", Json.Encode.int x.postId )
         , ( "text", Json.Encode.string x.text )
-        , ( "mainCategories", (tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
+        , ( "mainCategories", (Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
         , ( "published", Json.Encode.bool x.published )
         , ( "created", (Json.Encode.string << toString) x.created )
-        , ( "tags", (dict Json.Encode.string Json.Encode.int) x.tags )
+        , ( "tags", (Exts.Json.Encode.dict Json.Encode.string Json.Encode.int) x.tags )
         ]

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -10,8 +10,8 @@ encodeComment x =
     Json.Encode.object
         [ ( "commentPostId", Json.Encode.int x.postId )
         , ( "commentText", Json.Encode.string x.text )
-        , ( "commentMainCategories", (tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
+        , ( "commentMainCategories", (Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
         , ( "commentPublished", Json.Encode.bool x.published )
         , ( "commentCreated", (Json.Encode.string << toString) x.created )
-        , ( "commentTags", (dict Json.Encode.string Json.Encode.int) x.tags )
+        , ( "commentTags", (Exts.Json.Encode.dict Json.Encode.string Json.Encode.int) x.tags )
         ]

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -12,7 +12,7 @@ import           Data.IntMap
 import           Data.Map
 import           Data.Monoid
 import           Data.Proxy
-import           Data.Text                 hiding (lines, unlines)
+import           Data.Text                 hiding (head, lines, unlines)
 import           Data.Time
 import           Elm
 import           GHC.Generics
@@ -76,6 +76,7 @@ spec = do
   toElmTypeSpec
   toElmDecoderSpec
   toElmEncoderSpec
+  moduleSpecsSpec
 
 toElmTypeSpec :: Hspec.Spec
 toElmTypeSpec =
@@ -354,10 +355,29 @@ toElmEncoderSpec =
         "(Json.Encode.list << List.map (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
       it "toElmEncoderRef (Map String (Maybe String))" $
         toElmEncoderRef (Proxy :: Proxy (Map String (Maybe String))) `shouldBe`
-        "(dict Json.Encode.string (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
+        "(Exts.Json.Encode.dict Json.Encode.string (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
       it "toElmEncoderRef (IntMap (Maybe String))" $
         toElmEncoderRef (Proxy :: Proxy (IntMap (Maybe String))) `shouldBe`
-        "(dict Json.Encode.int (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
+        "(Exts.Json.Encode.dict Json.Encode.int (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
+
+moduleSpecsSpec :: Hspec.Spec
+moduleSpecsSpec =
+  describe "Generating a module Spec" $ do
+    let mySpec =
+          moduleSpec ["My", "Module"] $ do
+            renderType (Proxy :: Proxy Post)
+            renderDecoder (Proxy :: Proxy Post)
+            renderType (Proxy :: Proxy Comment)
+    it "sets the module namespace" $
+      namespace mySpec `shouldBe` ["My", "Module"]
+    it "inserts the correct imports" $
+      head (declarations mySpec) `shouldBe`
+      intercalate "\n"
+        [ "import Date"
+        , "import Dict"
+        , "import Json.Decode exposing (..)"
+        , "import Json.Decode.Pipeline exposing (..)"
+        ]
 
 shouldMatchTypeSource
   :: ElmType a


### PR DESCRIPTION
I mentioned this at last night's West London Hack Night.

Adds four new helpers for creating `Spec`s: `moduleSpec`, `renderType`, `renderDecoder` and `renderEncoder`.

Example:
```haskell
mySpec :: Spec
mySpec =
  moduleSpec ["My", "Module"] $ do
    renderType (Proxy :: Proxy MyType)
    renderDecoder (Proxy :: Proxy MyType)

main :: IO ()
main =
  specsToDir [mySpec] "elm-src"
```

The Elm imports required for defining `MyType` and its `Decoder` are automatically inserted. This should help solve issues like #19.

What do you think?

Edit: typos.