### PR TITLE
#29: fix toElmTypeRef for tuples, add tests

### DIFF
--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -64,8 +64,8 @@ instance HasTypeRef ElmPrimitive where
     dt <- renderRef datatype
     return $ "List" <+> parens dt
   renderRef (ETuple2 x y) = do
-    dx <- render x
-    dy <- render y
+    dx <- renderRef x
+    dy <- renderRef y
     return . parens $ dx <> comma <+> dy
   renderRef (EMaybe datatype) = do
     dt <- renderRef datatype

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -66,7 +66,7 @@ instance HasTypeRef ElmPrimitive where
   renderRef (ETuple2 x y) = do
     dx <- render x
     dy <- render y
-    return . spaceparens $ dx <> comma <+> dy
+    return . parens $ dx <> comma <+> dy
   renderRef (EMaybe datatype) = do
     dt <- renderRef datatype
     return $ "Maybe" <+> parens dt

--- a/test/CommentType.elm
+++ b/test/CommentType.elm
@@ -7,7 +7,7 @@ import Dict exposing (Dict)
 type alias Comment =
     { postId : Int
     , text : String
-    , mainCategories : ( String, String )
+    , mainCategories : (String, String)
     , published : Bool
     , created : Date
     , tags : Dict (String) (Int)

--- a/test/CommentTypeWithOptions.elm
+++ b/test/CommentTypeWithOptions.elm
@@ -7,7 +7,7 @@ import Dict exposing (Dict)
 type alias Comment =
     { commentPostId : Int
     , commentText : String
-    , commentMainCategories : ( String, String )
+    , commentMainCategories : (String, String)
     , commentPublished : Bool
     , commentCreated : Date
     , commentTags : Dict (String) (Int)

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -171,6 +171,8 @@ toElmTypeSpec =
         toElmTypeRef (Proxy :: Proxy Post) `shouldBe` "Post"
       it "toElmTypeRef [Comment]" $
         toElmTypeRef (Proxy :: Proxy [Comment]) `shouldBe` "List (Comment)"
+      it "toElmTypeRef (Comment, String)" $
+        toElmTypeRef (Proxy :: Proxy (Comment, String)) `shouldBe` "(Comment, String)"
       it "toElmTypeRef String" $
         toElmTypeRef (Proxy :: Proxy String) `shouldBe` "String"
       it "toElmTypeRef (Maybe String)" $


### PR DESCRIPTION
Fixes #29

Note: I've made tuples without extra space between parens, since that's the official Elm notation.

cc @krisajenkins 