### PR TITLE
Implements support for algebraic sum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The decoders we produce require these extra Elm packages installed:
 ``` sh
 elm package install NoRedInk/elm-decode-pipeline
 elm package install krisajenkins/elm-exts
+elm-package install justinmimbs/elm-date-extra
 ```
 
 ## Development

--- a/elm-export.cabal
+++ b/elm-export.cabal
@@ -23,6 +23,7 @@ library
                      , directory
                      , formatting
                      , mtl
+                     , semigroups
                      , text
                      , time
                      , wl-pprint-text

--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -52,3 +52,9 @@ declarations.
 collectDeclaration :: RenderM Doc -> RenderM ()
 collectDeclaration =
   mapRWS ((\(defn, (), (imports, _)) -> ((), (), (imports, [pprinter defn]))))
+
+squarebracks :: Doc -> Doc
+squarebracks doc = "[" <+> doc <+> "]"
+
+pair :: Doc -> Doc -> Doc
+pair l r = spaceparens $ l <> comma <+> r

--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -36,6 +36,18 @@ stext = text . LT.fromStrict
 spaceparens :: Doc -> Doc
 spaceparens doc = "(" <+> doc <+> ")"
 
+-- | Parentheses of which the right parenthesis exists on a new line
+newlineparens :: Doc -> Doc
+newlineparens doc = "(" <> doc <$$> ")"
+
+-- | An empty line, regardless of current indentation
+emptyline :: Doc
+emptyline = nest minBound linebreak
+
+-- | Like <$$>, but with an empty line in between
+(<$+$>) :: Doc -> Doc -> Doc
+l <$+$> r = l <> emptyline <$$> r
+
 --
 type RenderM = RWS Options (Set Text -- The set of required imports
                             , [Text] -- Generated declarations

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -112,7 +112,7 @@ instance HasDecoder ElmValue where
     fieldModifier <- asks fieldLabelModifier
     dv <- render value
     return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
-  render v = error $ "instance HasDecoder ElmValue: should not happen (" ++ show v ++ ")"
+  render ElmEmpty = pure (stext "")
 
 instance HasDecoderRef ElmPrimitive where
   renderRef (EList (ElmPrimitive EChar)) = pure "string"

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -112,6 +112,7 @@ instance HasDecoder ElmValue where
     fieldModifier <- asks fieldLabelModifier
     dv <- render value
     return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
+  render _ = error "instance HasDecoder ElmValue: should not happen"
 
 instance HasDecoderRef ElmPrimitive where
   renderRef (EList (ElmPrimitive EChar)) = pure "string"

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -112,7 +112,7 @@ instance HasDecoder ElmValue where
     fieldModifier <- asks fieldLabelModifier
     dv <- render value
     return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
-  render _ = error "instance HasDecoder ElmValue: should not happen"
+  render v = error $ "instance HasDecoder ElmValue: should not happen (" ++ show v ++ ")"
 
 instance HasDecoderRef ElmPrimitive where
   renderRef (EList (ElmPrimitive EChar)) = pure "string"

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -127,7 +127,7 @@ instance HasEncoder ElmValue where
   render _ = error "HasEncoderRef ElmValue: should not happen"
 
 instance HasEncoderRef ElmPrimitive where
-  renderRef EDate = pure $ parens "Json.Encode.string << toString"
+  renderRef EDate = pure $ parens "Json.Encode.string << toUtcIsoString"
   renderRef EUnit = pure "Json.Encode.null"
   renderRef EInt = pure "Json.Encode.int"
   renderRef EChar = pure "Json.Encode.char"

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -34,9 +34,79 @@ instance HasEncoderRef ElmDatatype where
   renderRef (ElmPrimitive primitive) = renderRef primitive
 
 instance HasEncoder ElmConstructor where
+  -- Single constructor, no values: empty array
+  render (NamedConstructor _name ElmEmpty) =
+    return $ "Json.Encode.list []"
+
+  -- Single constructor, multiple values: create array with values
+  render (NamedConstructor name value@(Values _ _)) = do
+    let ps = constructorParameters 0 value
+
+    (dv, _) <- renderVariable ps value
+
+    let cs = stext name <+> foldl1 (<+>) ps <+> "->"
+    return . nest 4 $ "case x of" <$$>
+      (nest 4 $ cs <+> "Json.Encode.list" <$$> "[" <+> dv <$$> "]")
+
+  -- Single constructor, one value: skip constructor and render just the value
+  render (NamedConstructor _name val) =
+    render val
+
+
   render (RecordConstructor _ value) = do
     dv <- render value
     return . nest 4 $ "Json.Encode.object" <$$> "[" <+> dv <$$> "]"
+
+  render mc@(MultipleConstructors constrs) = do
+    let rndr = if isEnumeration mc then renderEnumeration else renderSum
+    dc <- mapM rndr constrs
+    return . nest 4 $ "case x of" <$$> foldl1 (<$$>) dc
+
+renderSum :: ElmConstructor -> RenderM Doc
+renderSum c@(NamedConstructor name ElmEmpty) = do
+  dc <- render c
+  let cs = stext name <+> "->"
+  let tag = pair (dquotes "tag") ("Json.Encode.string" <+> dquotes (stext name))
+  let ct = comma <+> pair (dquotes "contents") dc
+  return . nest 4 $ cs <+> "Json.Encode.object" <$$> "[" <+> tag <$$>
+    ct <$$>
+    "]"
+
+renderSum (NamedConstructor name value) = do
+  let ps = constructorParameters 0 value
+
+  (dc, _) <- renderVariable ps value
+  let dc' = if length ps > 1 then "Json.Encode.list" <+> squarebracks dc else dc
+  let cs = stext name <+> foldl1 (<+>) ps <+> "->"
+  let tag = pair (dquotes "tag") ("Json.Encode.string" <+> dquotes (stext name))
+  let ct = comma <+> pair (dquotes "contents") dc'
+  return . nest 4 $ cs <+> "Json.Encode.object" <$$> "[" <+> tag <$$>
+    ct <$$>
+    "]"
+
+renderSum (RecordConstructor name value) = do
+  dv <- render value
+  let cs = stext name <+> "->"
+  let tag = pair (dquotes "tag") (dquotes $ stext name)
+  let ct = comma <+> dv
+  return . nest 4 $ cs <+> "Json.Encode.object" <$$> "[" <+> tag <$$>
+    ct <$$>
+    "]"
+
+renderSum (MultipleConstructors constrs) = do
+  dc <- mapM renderSum constrs
+  return $ foldl1 (<$$>) dc
+
+
+renderEnumeration :: ElmConstructor -> RenderM Doc
+renderEnumeration (NamedConstructor name _) =
+  return $ stext name <+> "->" <+>
+    "Json.Encode.string" <+> dquotes (stext name)
+renderEnumeration (MultipleConstructors constrs) = do
+  dc <- mapM renderEnumeration constrs
+  return $ foldl1 (<$$>) dc
+renderEnumeration c = render c
+
 
 instance HasEncoder ElmValue where
   render (ElmField name value) = do
@@ -106,3 +176,35 @@ renderEncoder
 renderEncoder x = do
   require "Json.Encode"
   collectDeclaration . render . toElmType $ x
+
+-- | Variable names for the members of constructors
+-- Used in pattern matches
+constructorParameters :: Int -> ElmValue -> [Doc]
+constructorParameters _ ElmEmpty = [ empty ]
+constructorParameters i (Values l r) =
+    left ++ right
+  where
+    left = constructorParameters i l
+    right = constructorParameters (length left + i) r
+constructorParameters i _ = [ "y" <> int i ]
+
+
+-- | Encode variables following the recipe of an ElmValue
+renderVariable :: [Doc] -> ElmValue -> RenderM (Doc, [Doc])
+renderVariable (d : ds) v@(ElmRef {}) = do
+  v' <- render v
+  return (v' <+> d, ds)
+renderVariable ds ElmEmpty = return (empty, ds)
+renderVariable (_ : ds) (ElmPrimitiveRef EUnit) =
+  return ("Json.Encode.null", ds)
+renderVariable (d : ds) (ElmPrimitiveRef ref) = do
+  r <- renderRef ref
+  return (r <+> d, ds)
+renderVariable ds (Values l r) = do
+  (left, dsl) <- renderVariable ds l
+  (right, dsr) <- renderVariable dsl r
+  return (left <> comma <+> right, dsr)
+renderVariable ds f@(ElmField _ _) = do
+  f' <- render f
+  return (f', ds)
+renderVariable [] _ = error "Amount of variables does not match variables"

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -124,6 +124,7 @@ instance HasEncoder ElmValue where
     dx <- render x
     dy <- render y
     return $ dx <$$> comma <+> dy
+  render _ = error "HasEncoderRef ElmValue: should not happen"
 
 instance HasEncoderRef ElmPrimitive where
   renderRef EDate = pure $ parens "Json.Encode.string << toString"

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -12,7 +12,7 @@ import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IntMap
 import Data.Map
 import Data.Proxy
-import Data.Text
+import Data.Text hiding (all)
 import Data.Time
 import GHC.Generics
 import Prelude
@@ -199,3 +199,11 @@ instance ElmType Char where
 
 instance ElmType Bool where
   toElmType _ = ElmPrimitive EBool
+
+-- | Whether a set of constructors is an enumeration, i.e. whether they lack
+-- values. data A = A | B | C would be simple data A = A Int | B | C would not
+-- be simple.
+isEnumeration :: ElmConstructor -> Bool
+isEnumeration (NamedConstructor _ ElmEmpty) = True
+isEnumeration (MultipleConstructors cs) = all isEnumeration cs
+isEnumeration _ = False

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -15,6 +15,7 @@ import Data.Proxy
 import Data.Text hiding (all)
 import Data.Time
 import GHC.Generics
+import Numeric.Natural (Natural)
 import Prelude
 
 data ElmDatatype
@@ -160,6 +161,9 @@ instance ElmType Int32 where
   toElmType _ = ElmPrimitive EInt
 
 instance ElmType Int64 where
+  toElmType _ = ElmPrimitive EInt
+
+instance ElmType Natural where
   toElmType _ = ElmPrimitive EInt
 
 instance (ElmType a, ElmType b) =>

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -10,6 +10,7 @@ module Elm.Type where
 
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IntMap
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map
 import Data.Proxy
 import Data.Text hiding (all)
@@ -128,6 +129,10 @@ instance ElmType a =>
 instance ElmType a =>
          ElmType [a] where
   toElmType _ = ElmPrimitive (EList (toElmType (Proxy :: Proxy a)))
+
+instance ElmType a =>
+         ElmType (NonEmpty a) where
+  toElmType _ = toElmType (Proxy :: Proxy [a])
 
 instance ElmType a =>
          ElmType (Maybe a) where

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -55,6 +55,12 @@ data Timing
   | Stop
   deriving (Generic, ElmType)
 
+data Monstrosity
+  = NotSpecial
+  | OkayIGuess Monstrosity
+  | Ridiculous Int String [Monstrosity]
+  deriving (Generic, ElmType)
+
 newtype Useless =
   Useless ()
   deriving (Generic, ElmType)
@@ -120,6 +126,12 @@ toElmTypeSpec =
         defaultOptions
         (Proxy :: Proxy Timing)
         "test/TimingType.elm"
+    it "toElmTypeSource Monstrosity" $
+      shouldMatchTypeSource
+        (unlines ["module MonstrosityType exposing (..)", "", "", "%s"])
+        defaultOptions
+        (Proxy :: Proxy Monstrosity)
+        "test/MonstrosityType.elm"
     it "toElmTypeSource Useless" $
       shouldMatchTypeSource
         (unlines ["module UselessType exposing (..)", "", "", "%s"])
@@ -241,6 +253,51 @@ toElmDecoderSpec =
         (defaultOptions {fieldLabelModifier = withPrefix "post"})
         (Proxy :: Proxy Post)
         "test/PostDecoderWithOptions.elm"
+    it "toElmDecoderSource Position" $
+      shouldMatchDecoderSource
+        (unlines
+           [ "module PositionDecoder exposing (..)"
+           , ""
+           , "import Json.Decode exposing (..)"
+           , "import Json.Decode.Pipeline exposing (..)"
+           , "import PositionType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Position)
+        "test/PositionDecoder.elm"
+    it "toElmDecoderSource Timing" $
+      shouldMatchDecoderSource
+        (unlines
+           [ "module TimingDecoder exposing (..)"
+           , ""
+           , "import Json.Decode exposing (..)"
+           , "import Json.Decode.Pipeline exposing (..)"
+           , "import TimingType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Timing)
+        "test/TimingDecoder.elm"
+    it "toElmDecoderSource Monstrosity" $
+      shouldMatchDecoderSource
+        (unlines
+           [ "module MonstrosityDecoder exposing (..)"
+           , ""
+           , "import Json.Decode exposing (..)"
+           , "import Json.Decode.Pipeline exposing (..)"
+           , "import MonstrosityType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Monstrosity)
+        "test/MonstrosityDecoder.elm"
     it "toElmDecoderSourceWithOptions Comment" $
       shouldMatchDecoderSource
         (unlines
@@ -258,9 +315,30 @@ toElmDecoderSpec =
         (defaultOptions {fieldLabelModifier = withPrefix "comment"})
         (Proxy :: Proxy Comment)
         "test/CommentDecoderWithOptions.elm"
+    it "toElmDecoderSource Useless" $
+      shouldMatchDecoderSource
+        (unlines
+           [ "module UselessDecoder exposing (..)"
+           , ""
+           , "import Json.Decode exposing (..)"
+           , "import Json.Decode.Pipeline exposing (..)"
+           , "import UselessType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Useless)
+        "test/UselessDecoder.elm"
     describe "Convert to Elm decoder references." $ do
       it "toElmDecoderRef Post" $
         toElmDecoderRef (Proxy :: Proxy Post) `shouldBe` "decodePost"
+      it "toElmDecoderRef Position" $
+        toElmDecoderRef (Proxy :: Proxy Position) `shouldBe` "decodePosition"
+      it "toElmDecoderRef Timing" $
+        toElmDecoderRef (Proxy :: Proxy Timing) `shouldBe` "decodeTiming"
+      it "toElmDecoderRef Monstrosity" $
+        toElmDecoderRef (Proxy :: Proxy Monstrosity) `shouldBe` "decodeMonstrosity"
       it "toElmDecoderRef [Comment]" $
         toElmDecoderRef (Proxy :: Proxy [Comment]) `shouldBe`
         "(list decodeComment)"
@@ -342,12 +420,60 @@ toElmEncoderSpec =
         (defaultOptions {fieldLabelModifier = withPrefix "post"})
         (Proxy :: Proxy Post)
         "test/PostEncoderWithOptions.elm"
+    it "toElmEncoderSource Position" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module PositionEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import PositionType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Position)
+        "test/PositionEncoder.elm"
+    it "toElmEncoderSourceWithOptions Timing" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module TimingEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import TimingType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Timing)
+        "test/TimingEncoder.elm"
+    it "toElmEncoderSourceWithOptions Monstrosity" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module MonstrosityEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import MonstrosityType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Monstrosity)
+        "test/MonstrosityEncoder.elm"
     describe "Convert to Elm encoder references." $ do
       it "toElmEncoderRef Post" $
         toElmEncoderRef (Proxy :: Proxy Post) `shouldBe` "encodePost"
       it "toElmEncoderRef [Comment]" $
         toElmEncoderRef (Proxy :: Proxy [Comment]) `shouldBe`
         "(Json.Encode.list << List.map encodeComment)"
+      it "toElmEncoderRef Position" $
+        toElmEncoderRef (Proxy :: Proxy Position) `shouldBe` "encodePosition"
+      it "toElmEncoderRef Timing" $
+        toElmEncoderRef (Proxy :: Proxy Timing) `shouldBe` "encodeTiming"
+      it "toElmEncoderRef Monstrosity" $
+        toElmEncoderRef (Proxy :: Proxy Monstrosity) `shouldBe` "encodeMonstrosity"
       it "toElmEncoderRef String" $
         toElmEncoderRef (Proxy :: Proxy String) `shouldBe` "Json.Encode.string"
       it "toElmEncoderRef (Maybe String)" $

--- a/test/MonstrosityDecoder.elm
+++ b/test/MonstrosityDecoder.elm
@@ -1,0 +1,14 @@
+module MonstrosityDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import MonstrosityType exposing (..)
+
+
+decodeMonstrosity : Decoder Monstrosity
+decodeMonstrosity =
+    field "tag" string |> andThen ( \x ->
+        if x == "NotSpecial" then decode NotSpecial
+        else if x == "OkayIGuess" then decode OkayIGuess |> required "contents" decodeMonstrosity
+        else if x == "Ridiculous" then decode Ridiculous |> required "contents" (index 0 int) |> required "contents" (index 1 string) |> required "contents" (index 2 (list decodeMonstrosity))
+        else fail "Constructor not matched" )

--- a/test/MonstrosityDecoder.elm
+++ b/test/MonstrosityDecoder.elm
@@ -7,8 +7,23 @@ import MonstrosityType exposing (..)
 
 decodeMonstrosity : Decoder Monstrosity
 decodeMonstrosity =
-    field "tag" string |> andThen ( \x ->
-        if x == "NotSpecial" then decode NotSpecial
-        else if x == "OkayIGuess" then decode OkayIGuess |> required "contents" decodeMonstrosity
-        else if x == "Ridiculous" then decode Ridiculous |> required "contents" (index 0 int) |> required "contents" (index 1 string) |> required "contents" (index 2 (list decodeMonstrosity))
-        else fail "Constructor not matched" )
+    field "tag" string
+        |> andThen
+            (\x ->
+                case x of
+                    "NotSpecial" ->
+                        decode NotSpecial
+
+                    "OkayIGuess" ->
+                        decode OkayIGuess
+                            |> required "contents" decodeMonstrosity
+
+                    "Ridiculous" ->
+                        decode Ridiculous
+                            |> required "contents" (index 0 int)
+                            |> required "contents" (index 1 string)
+                            |> required "contents" (index 2 (list decodeMonstrosity))
+
+                    _ ->
+                        fail "Constructor not matched"
+            )

--- a/test/MonstrosityEncoder.elm
+++ b/test/MonstrosityEncoder.elm
@@ -1,0 +1,21 @@
+module MonstrosityEncoder exposing (..)
+
+import Json.Encode
+import MonstrosityType exposing (..)
+
+
+encodeMonstrosity : Monstrosity -> Json.Encode.Value
+encodeMonstrosity x =
+    case x of
+        NotSpecial -> Json.Encode.object
+            [ ( "tag", Json.Encode.string "NotSpecial" )
+            , ( "contents", Json.Encode.list [] )
+            ]
+        OkayIGuess y0 -> Json.Encode.object
+            [ ( "tag", Json.Encode.string "OkayIGuess" )
+            , ( "contents", encodeMonstrosity y0 )
+            ]
+        Ridiculous y0 y1 y2 -> Json.Encode.object
+            [ ( "tag", Json.Encode.string "Ridiculous" )
+            , ( "contents", Json.Encode.list [ Json.Encode.int y0, Json.Encode.string y1, (Json.Encode.list << List.map encodeMonstrosity) y2 ] )
+            ]

--- a/test/MonstrosityEncoder.elm
+++ b/test/MonstrosityEncoder.elm
@@ -7,15 +7,20 @@ import MonstrosityType exposing (..)
 encodeMonstrosity : Monstrosity -> Json.Encode.Value
 encodeMonstrosity x =
     case x of
-        NotSpecial -> Json.Encode.object
-            [ ( "tag", Json.Encode.string "NotSpecial" )
-            , ( "contents", Json.Encode.list [] )
-            ]
-        OkayIGuess y0 -> Json.Encode.object
-            [ ( "tag", Json.Encode.string "OkayIGuess" )
-            , ( "contents", encodeMonstrosity y0 )
-            ]
-        Ridiculous y0 y1 y2 -> Json.Encode.object
-            [ ( "tag", Json.Encode.string "Ridiculous" )
-            , ( "contents", Json.Encode.list [ Json.Encode.int y0, Json.Encode.string y1, (Json.Encode.list << List.map encodeMonstrosity) y2 ] )
-            ]
+        NotSpecial ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "NotSpecial" )
+                , ( "contents", Json.Encode.list [] )
+                ]
+
+        OkayIGuess y0 ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "OkayIGuess" )
+                , ( "contents", encodeMonstrosity y0 )
+                ]
+
+        Ridiculous y0 y1 y2 ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "Ridiculous" )
+                , ( "contents", Json.Encode.list [ Json.Encode.int y0, Json.Encode.string y1, (Json.Encode.list << List.map encodeMonstrosity) y2 ] )
+                ]

--- a/test/MonstrosityType.elm
+++ b/test/MonstrosityType.elm
@@ -1,0 +1,7 @@
+module MonstrosityType exposing (..)
+
+
+type Monstrosity
+    = NotSpecial
+    | OkayIGuess Monstrosity
+    | Ridiculous Int String (List (Monstrosity))

--- a/test/PositionDecoder.elm
+++ b/test/PositionDecoder.elm
@@ -7,8 +7,19 @@ import PositionType exposing (..)
 
 decodePosition : Decoder Position
 decodePosition =
-    string |> andThen ( \x ->
-        if x == "Beginning" then decode Beginning
-        else if x == "Middle" then decode Middle
-        else if x == "End" then decode End
-        else fail "Constructor not matched" )
+    string
+        |> andThen
+            (\x ->
+                case x of
+                    "Beginning" ->
+                        decode Beginning
+
+                    "Middle" ->
+                        decode Middle
+
+                    "End" ->
+                        decode End
+
+                    _ ->
+                        fail "Constructor not matched"
+            )

--- a/test/PositionDecoder.elm
+++ b/test/PositionDecoder.elm
@@ -1,0 +1,14 @@
+module PositionDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import PositionType exposing (..)
+
+
+decodePosition : Decoder Position
+decodePosition =
+    string |> andThen ( \x ->
+        if x == "Beginning" then decode Beginning
+        else if x == "Middle" then decode Middle
+        else if x == "End" then decode End
+        else fail "Constructor not matched" )

--- a/test/PositionEncoder.elm
+++ b/test/PositionEncoder.elm
@@ -7,6 +7,11 @@ import PositionType exposing (..)
 encodePosition : Position -> Json.Encode.Value
 encodePosition x =
     case x of
-        Beginning -> Json.Encode.string "Beginning"
-        Middle -> Json.Encode.string "Middle"
-        End -> Json.Encode.string "End"
+        Beginning ->
+            Json.Encode.string "Beginning"
+
+        Middle ->
+            Json.Encode.string "Middle"
+
+        End ->
+            Json.Encode.string "End"

--- a/test/PositionEncoder.elm
+++ b/test/PositionEncoder.elm
@@ -1,0 +1,12 @@
+module PositionEncoder exposing (..)
+
+import Json.Encode
+import PositionType exposing (..)
+
+
+encodePosition : Position -> Json.Encode.Value
+encodePosition x =
+    case x of
+        Beginning -> Json.Encode.string "Beginning"
+        Middle -> Json.Encode.string "Middle"
+        End -> Json.Encode.string "End"

--- a/test/TimingDecoder.elm
+++ b/test/TimingDecoder.elm
@@ -1,0 +1,14 @@
+module TimingDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import TimingType exposing (..)
+
+
+decodeTiming : Decoder Timing
+decodeTiming =
+    field "tag" string |> andThen ( \x ->
+        if x == "Start" then decode Start
+        else if x == "Continue" then decode Continue |> required "contents" float
+        else if x == "Stop" then decode Stop
+        else fail "Constructor not matched" )

--- a/test/TimingDecoder.elm
+++ b/test/TimingDecoder.elm
@@ -7,8 +7,20 @@ import TimingType exposing (..)
 
 decodeTiming : Decoder Timing
 decodeTiming =
-    field "tag" string |> andThen ( \x ->
-        if x == "Start" then decode Start
-        else if x == "Continue" then decode Continue |> required "contents" float
-        else if x == "Stop" then decode Stop
-        else fail "Constructor not matched" )
+    field "tag" string
+        |> andThen
+            (\x ->
+                case x of
+                    "Start" ->
+                        decode Start
+
+                    "Continue" ->
+                        decode Continue
+                            |> required "contents" float
+
+                    "Stop" ->
+                        decode Stop
+
+                    _ ->
+                        fail "Constructor not matched"
+            )

--- a/test/TimingEncoder.elm
+++ b/test/TimingEncoder.elm
@@ -1,0 +1,21 @@
+module TimingEncoder exposing (..)
+
+import Json.Encode
+import TimingType exposing (..)
+
+
+encodeTiming : Timing -> Json.Encode.Value
+encodeTiming x =
+    case x of
+        Start -> Json.Encode.object
+            [ ( "tag", Json.Encode.string "Start" )
+            , ( "contents", Json.Encode.list [] )
+            ]
+        Continue y0 -> Json.Encode.object
+            [ ( "tag", Json.Encode.string "Continue" )
+            , ( "contents", Json.Encode.float y0 )
+            ]
+        Stop -> Json.Encode.object
+            [ ( "tag", Json.Encode.string "Stop" )
+            , ( "contents", Json.Encode.list [] )
+            ]

--- a/test/TimingEncoder.elm
+++ b/test/TimingEncoder.elm
@@ -7,15 +7,20 @@ import TimingType exposing (..)
 encodeTiming : Timing -> Json.Encode.Value
 encodeTiming x =
     case x of
-        Start -> Json.Encode.object
-            [ ( "tag", Json.Encode.string "Start" )
-            , ( "contents", Json.Encode.list [] )
-            ]
-        Continue y0 -> Json.Encode.object
-            [ ( "tag", Json.Encode.string "Continue" )
-            , ( "contents", Json.Encode.float y0 )
-            ]
-        Stop -> Json.Encode.object
-            [ ( "tag", Json.Encode.string "Stop" )
-            , ( "contents", Json.Encode.list [] )
-            ]
+        Start ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "Start" )
+                , ( "contents", Json.Encode.list [] )
+                ]
+
+        Continue y0 ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "Continue" )
+                , ( "contents", Json.Encode.float y0 )
+                ]
+
+        Stop ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "Stop" )
+                , ( "contents", Json.Encode.list [] )
+                ]

--- a/test/UselessDecoder.elm
+++ b/test/UselessDecoder.elm
@@ -1,0 +1,11 @@
+module UselessDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import UselessType exposing (..)
+
+
+decodeUseless : Decoder Useless
+decodeUseless =
+    decode Useless
+        (succeed ())


### PR DESCRIPTION
Please review before merging. Some things were done quickly, and I haven't tested aeson compatibility yet, which I still plan to do.

[update] Aeson compatibility has now been tested. See next post.

See #6 

## Things done
- Added tests for encoders and decoders of Timing and Position
- Implemented encoders and decoders for data types with multiple constructors. It was designed to be compatible with the whims of aeson, though this hasn't been tested just yet.
- Added a new test type: `Monstrosity`, which revealed some bugs in the original implementation (and in my implementation of encoders and decoders)
- Fixed those bugs

## Some background
As you mentioned in this [issue comment](https://github.com/krisajenkins/elm-export/issues/6#issuecomment-207621975), Aeson is very specific about the json structure it generates. Differences depend on the following factors:

- Whether one or more constructors are a record type (in Haskell)
- Whether there are multiple constructors
- Whether there are constructors that have arguments

Really annoying, but the code in this PR *should* be compatible with it, though I've yet to test that. I *do* know, however, that the generated code compiles with Elm 0.18 and is correctly typed. That I *did* test.