### PR TITLE
Add HasElmComparable instance for Text

### DIFF
--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -188,6 +188,9 @@ class HasElmComparable a where
 instance HasElmComparable String where
   toElmComparable _ = EString
 
+instance HasElmComparable Text where
+  toElmComparable _ = EString
+
 instance ElmType Int where
   toElmType _ = ElmPrimitive EInt
 


### PR DESCRIPTION
I was trying to export code using `servant-elm` for a `Map` keyed on `Text` and ran into this error:

```
 No instance for (elm-export-0.6.0.1:Elm.Type.HasElmComparable
                         Data.Text.Internal.Text)
        arising from a use of ‘generateElmForAPIWith’
```

Adding the extra instance for Text seems to have fixed the problem.