### PR TITLE
Add Aeson's 'Value' as an Elm type

### DIFF
--- a/elm-export.cabal
+++ b/elm-export.cabal
@@ -18,6 +18,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Elm
   build-depends:       base >= 4.7 && < 5
+                     , aeson
                      , bytestring
                      , containers
                      , directory

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -84,6 +84,7 @@ instance HasDecoderRef ElmPrimitive where
   renderRef EChar = pure "char"
   renderRef EFloat = pure "float"
   renderRef EString = pure "string"
+  renderRef EValue = pure "value"
 
 toElmDecoderRefWith
   :: ElmType a

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -60,6 +60,7 @@ instance HasEncoderRef ElmPrimitive where
   renderRef EBool = pure "Json.Encode.bool"
   renderRef EFloat = pure "Json.Encode.float"
   renderRef EString = pure "Json.Encode.string"
+  renderRef EValue = pure "identity"
   renderRef (EList (ElmPrimitive EChar)) = pure "Json.Encode.string"
   renderRef (EList datatype) = do
     dd <- renderRef datatype

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -79,6 +79,9 @@ instance HasTypeRef ElmPrimitive where
   renderRef EDate = do
     require "Date"
     pure "Date"
+  renderRef EValue = do
+    require "Json.Decode"
+    pure "Value"
   renderRef EBool = pure "Bool"
   renderRef EChar = pure "Char"
   renderRef EString = pure "String"

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -8,6 +8,7 @@
 
 module Elm.Type where
 
+import Data.Aeson (Value)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IntMap
 import Data.Map
@@ -31,6 +32,7 @@ data ElmPrimitive
   | EFloat
   | EString
   | EUnit
+  | EValue
   | EList ElmDatatype
   | EMaybe ElmDatatype
   | ETuple2 ElmDatatype
@@ -161,6 +163,9 @@ instance ElmType Int32 where
 
 instance ElmType Int64 where
   toElmType _ = ElmPrimitive EInt
+
+instance ElmType Value where
+  toElmType _ = ElmPrimitive EValue
 
 instance (ElmType a, ElmType b) =>
          ElmType (a, b) where


### PR DESCRIPTION
Sometimes it is useful to return pure JSON to the client from the server and
deal with it there. Since Elm also has a corresponding 'Value' type (the same
one in Json.Encode and Json.Decode), the implementation is straightforward.

My use case is that I have some client settings in a `jsonb` postgresql column, which are pulled down when a user logs in. I don't really want to have a corresponding type for them on the server.

This requires adding aeson to the dependencies list, but I guess elm-export users will be using aeson anyway.