### PR TITLE
fieldModifier should apply to encoder names as well

### DIFF
--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -44,7 +44,7 @@ instance HasEncoder ElmValue where
     valueBody <- render value
     return . spaceparens $
       dquotes (stext (fieldModifier name)) <> comma <+>
-      (valueBody <+> "x." <> stext name)
+      (valueBody <+> "x." <> stext (fieldModifier name))
   render (ElmPrimitiveRef primitive) = renderRef primitive
   render (ElmRef name) = pure $ "encode" <> stext name
   render (Values x y) = do


### PR DESCRIPTION
When I have:

<img width="282" alt="screenshot 2017-11-30 17 29 12" src="https://user-images.githubusercontent.com/102781/33445144-01071eda-d5f4-11e7-86b8-863064bb4a6f.png">

And I'm using the `fieldLabelModifier`:

<img width="650" alt="screenshot 2017-11-30 17 29 48" src="https://user-images.githubusercontent.com/102781/33445178-17ea615c-d5f4-11e7-9444-d838d3b4f9ef.png">

The `fieldLabelModifier` should apply to the `encoder` field as well, otherwise, my types are mismatched:

<img width="917" alt="screenshot 2017-11-30 17 28 25" src="https://user-images.githubusercontent.com/102781/33445207-292ef112-d5f4-11e7-871c-69f205ff85a9.png">


