### PR TITLE
Modify values on toElmEncoderSourceWith 

### DIFF
--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -10,11 +10,10 @@ import           Formatting hiding (text)
 
 data Options = Options
   { fieldLabelModifier :: Text -> Text
-  , fieldValueModifier :: Text -> Text
   }
 
 defaultOptions :: Options
-defaultOptions = Options {fieldLabelModifier = id, fieldValueModifier = id}
+defaultOptions = Options {fieldLabelModifier = id}
 
 cr :: Format r r
 cr = now "\n"

--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -10,10 +10,11 @@ import           Formatting hiding (text)
 
 data Options = Options
   { fieldLabelModifier :: Text -> Text
+  , fieldValueModifier :: Text -> Text
   }
 
 defaultOptions :: Options
-defaultOptions = Options {fieldLabelModifier = id}
+defaultOptions = Options {fieldLabelModifier = id, fieldValueModifier = id}
 
 cr :: Format r r
 cr = now "\n"

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -40,12 +40,11 @@ instance HasEncoder ElmConstructor where
 
 instance HasEncoder ElmValue where
   render (ElmField name value) = do
-    fieldLabelModifier' <- asks fieldLabelModifier
-    fieldValueModifier' <- asks fieldValueModifier
+    fieldModifier <- asks fieldLabelModifier
     valueBody <- render value
     return . spaceparens $
-      dquotes (stext (fieldLabelModifier' name)) <> comma <+>
-      (valueBody <+> "x." <> stext (fieldValueModifier' name))
+      dquotes (stext (fieldModifier name)) <> comma <+>
+      (valueBody <+> "x." <> stext (fieldModifier name))
   render (ElmPrimitiveRef primitive) = renderRef primitive
   render (ElmRef name) = pure $ "encode" <> stext name
   render (Values x y) = do

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -40,11 +40,12 @@ instance HasEncoder ElmConstructor where
 
 instance HasEncoder ElmValue where
   render (ElmField name value) = do
-    fieldModifier <- asks fieldLabelModifier
+    fieldLabelModifier' <- asks fieldLabelModifier
+    fieldValueModifier' <- asks fieldValueModifier
     valueBody <- render value
     return . spaceparens $
-      dquotes (stext (fieldModifier name)) <> comma <+>
-      (valueBody <+> "x." <> stext name)
+      dquotes (stext (fieldLabelModifier' name)) <> comma <+>
+      (valueBody <+> "x." <> stext (fieldValueModifier' name))
   render (ElmPrimitiveRef primitive) = renderRef primitive
   render (ElmRef name) = pure $ "encode" <> stext name
   render (Values x y) = do


### PR DESCRIPTION
If `toElmTypeSourceWith` is used with a fieldLabelModifier, it's corresponding `toElmEncoderSourceWith` gets the wrong values.